### PR TITLE
fix filename, export helper types/interfaces

### DIFF
--- a/BigDecimal.d.ts
+++ b/BigDecimal.d.ts
@@ -39,4 +39,4 @@ declare class BigDecimal {
     static min(a: BigDecimal, b: BigDecimal): BigDecimal;
 }
 
-export default BigDecimal;
+export { BigDecimal, Rounding, RoundingMode };

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.34",
   "description": "Arbitrary precision decimal arithmetic library. Polyfill for decimal proposal. Implemented on the top of BigInt.",
   "main": "BigDecimal.js",
+  "types": "BigDecimal.d.ts",
   "scripts": {
     "test": "node --experimental-modules tests.js"
   },
@@ -18,7 +19,8 @@
     "bigdecimal"
   ],
   "files": [
-    "BigDecimal.js"
+    "BigDecimal.js",
+    "BigDecimal.d.ts"
   ],
   "author": "Viktor Mukhachev",
   "license": "ISC",


### PR DESCRIPTION
I also noticed that the typings didn't actually make it to the npm package. Hopefully this package.json change will make that happen, but I'm no npm pro.

I'm also not 100% sure what the deal is with default exports vs named exports, but the js module produces named exports - I think the two ought to match.

With this, I can do

import {BigDecimal} from "@yaffle/bigdecimal"

in my ts setup.